### PR TITLE
gnome-base/librsvg Add src_install function and revise autogen.yaml

### DIFF
--- a/gnome-base/librsvg/autogen.yaml
+++ b/gnome-base/librsvg/autogen.yaml
@@ -5,6 +5,8 @@ librsvg_rule:
         extensions:
           - rust
         version: 2.54.7
+        revision:
+          2.54.7: 1
         github:
           user: GNOME
           repo: librsvg

--- a/gnome-base/librsvg/templates/librsvg.tmpl
+++ b/gnome-base/librsvg/templates/librsvg.tmpl
@@ -65,6 +65,10 @@ src_compile() {
 	gnome3_src_compile
 }
 
+src_install() {
+    gnome3_src_install
+}
+
 pkg_postinst() {
 	# causes segfault if set, see bug 375615
 	unset __GL_NO_DSO_FINALIZER


### PR DESCRIPTION
Summary
========
* Implemented the src_install function in librsvg.tmpl to ensure proper installation procedures. 
* Updated autogen.yaml to include a revision field for version 2.54.7 to force a reemerging

* Emerge it
```
Updating /etc/portage/repos.conf...
Updating profiles at /etc/portage/make.profile/parent...
Updating non-funtoo repositories...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-python/six-1.17.0::python-modules-kit [1.16.0::python-modules-kit] USE="-doc -test" PYTHON_TARGETS="python3_9 -pypy3 -python2_7 -python3_10 -python3_7 -python3_8" 34 KiB
[ebuild     U  ] gnome-base/librsvg-2.54.7-r1:2::gnome-kit [2.54.7:2::gnome-kit] USE="introspection memsaver vala -debug -gtk-doc" 0 KiB

Total: 2 packages (2 upgrades), Size of downloads: 34 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 2) dev-python/six-1.17.0::python-modules-kit
>>> Installing (1 of 2) dev-python/six-1.17.0::python-modules-kit
>>> Emerging (2 of 2) gnome-base/librsvg-2.54.7-r1::gnome-kit
>>> Installing (2 of 2) gnome-base/librsvg-2.54.7-r1::gnome-kit
>>> Jobs: 2 of 2 complete                           Load avg: 4.61, 3.02, 2.15
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
 * After world updates, it is important to remove obsolete packages with
 * emerge --depclean. Refer to `man emerge` for more information.

```